### PR TITLE
Removing messages log for production

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,6 +220,15 @@ module.exports = function (grunt) {
         }]
       }
     },
+    strip : {
+      main : {
+        src : '<%= yeoman.dist %>/scripts/scripts.js',
+        dest : '<%= yeoman.dist %>/scripts/scripts.js',
+        options : {
+          nodes : ['console.', '$log.']
+        }
+      }
+    },
     uglify: {
       dist: {
         files: {
@@ -294,6 +303,7 @@ module.exports = function (grunt) {
     'copy',
     'cdnify',
     'ngmin',
+    'strip',
     'uglify',
     'rev',
     'usemin'

--- a/app/scripts/angular-smooth-scroll.coffee
+++ b/app/scripts/angular-smooth-scroll.coffee
@@ -87,10 +87,10 @@ angular.module('angularSmoothscroll', [])
       element.bind 'click', ->
         if attr.target
           offset = attr.offset or 100
-          #$log.log 'Smooth scroll: scrolling to', attr.target, 'with offset', offset
+          $log.log 'Smooth scroll: scrolling to', attr.target, 'with offset', offset
           smoothScroll attr.target, offset
-        #else
-        #  $log.warn 'Smooth scroll: no target specified'
+        else
+          $log.warn 'Smooth scroll: no target specified'
   ])
   .directive('smoothScrollJquery', ['$log', ($log) ->
     restrict: 'A'
@@ -100,9 +100,9 @@ angular.module('angularSmoothscroll', [])
           offset = attr.offset or 100;
           target = $('#'+attr.target)
           speed = attr.speed or 500
-          #$log.log 'Smooth scroll jQuery: scrolling to', attr.target, 'with offset', offset, 'and speed', speed
+          $log.log 'Smooth scroll jQuery: scrolling to', attr.target, 'with offset', offset, 'and speed', speed
           $('html,body').stop().animate({scrollTop: target.offset().top - offset}, speed)
         else
-          #$log.log 'Smooth scroll jQuery: no target specified, scrolling to top'  
+          $log.log 'Smooth scroll jQuery: no target specified, scrolling to top'  
           $('html,body').stop().animate({scrollTop: 0}, speed);
   ])

--- a/app/scripts/angular-smooth-scroll.coffee
+++ b/app/scripts/angular-smooth-scroll.coffee
@@ -87,10 +87,10 @@ angular.module('angularSmoothscroll', [])
       element.bind 'click', ->
         if attr.target
           offset = attr.offset or 100
-          $log.log 'Smooth scroll: scrolling to', attr.target, 'with offset', offset
+          #$log.log 'Smooth scroll: scrolling to', attr.target, 'with offset', offset
           smoothScroll attr.target, offset
-        else
-          $log.warn 'Smooth scroll: no target specified'
+        #else
+        #  $log.warn 'Smooth scroll: no target specified'
   ])
   .directive('smoothScrollJquery', ['$log', ($log) ->
     restrict: 'A'
@@ -100,9 +100,9 @@ angular.module('angularSmoothscroll', [])
           offset = attr.offset or 100;
           target = $('#'+attr.target)
           speed = attr.speed or 500
-          $log.log 'Smooth scroll jQuery: scrolling to', attr.target, 'with offset', offset, 'and speed', speed
+          #$log.log 'Smooth scroll jQuery: scrolling to', attr.target, 'with offset', offset, 'and speed', speed
           $('html,body').stop().animate({scrollTop: target.offset().top - offset}, speed)
         else
-          $log.log 'Smooth scroll jQuery: no target specified, scrolling to top'  
+          #$log.log 'Smooth scroll jQuery: no target specified, scrolling to top'  
           $('html,body').stop().animate({scrollTop: 0}, speed);
   ])

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "angular-smoothscroll",
   "version": "0.0.0",
-  "dependencies": {},
+  "dependencies": {
+    "grunt-strip": "~0.2.1"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.0",
@@ -24,7 +26,8 @@
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.1",
     "grunt-google-cdn": "~0.1.1",
-    "grunt-ngmin": "~0.0.2"
+    "grunt-ngmin": "~0.0.2",
+    "grunt-strip": "~0.2.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
In production, for a website, there can't be still log messages from the plugin. Even more if there's no problem.
For development, these messages can be re-opened for the debug, that's why they were left in comments.
