### PR TITLE
Changing jquery, angular, es5-shim, and json3 dependencies to use the caret operator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,10 @@
     "version": "1.1.0",
     "main": "dist/scripts/2d8e100/scripts.js",
     "dependencies": {
-        "jquery": "~1.9.1",
-        "angular": "~1.2.6",
-        "es5-shim": "~2.1.0",
-        "json3": "~3.2.6"
+        "jquery": "^1.9.1",
+        "angular": "^1.2.6",
+        "es5-shim": "^2.1.0",
+        "json3": "^3.2.6"
     },
     "devDependencies": {
         "angular-mocks": "~1.0.7",

--- a/bower.json
+++ b/bower.json
@@ -9,8 +9,8 @@
         "json3": "^3.2.6"
     },
     "devDependencies": {
-        "angular-mocks": "~1.0.7",
-        "angular-scenario": "~1.0.7"
+        "angular-mocks": "^1.0.7",
+        "angular-scenario": "^1.0.7"
     },
     "ignore": [
         "**/.*",


### PR DESCRIPTION
so that the dependencies can be satisfied with any minor and patch version such as angular 1.3.0 or jquery 1.11.0

If you do accept this, please update the tag. 
