### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ angular-smoothscroll
 AngularJS directives to get a smooth scroll effect (like this: http://css-tricks.com/examples/SmoothPageScroll/).
 Pure vanilla JS and jQuery versions.
 
-#How to use it?
+# How to use it?
 
 ## Demo 
 
@@ -25,28 +25,28 @@ Copy the last version from the `dist/scripts` folder
 
 Run `bower install angular-smoothscroll` in your project
 
-###Add the dependency to your app 
+### Add the dependency to your app 
 Declare an AngularJS module with a dependency: `app.module('myApp', ['angularSmoothscroll'])`
 
-##Vanilla JS (to improve, too fast) 
+## Vanilla JS (to improve, too fast) 
 
 Just declare an HTML link element which will start scroll, add the `smooth-scroll` directive and pass the target ID: `<a smooth-scroll target="target">Scroll to Target</a>`
 
-##jQuery version 
+## jQuery version 
 Declare an HTML link element which will start scroll, add the `smooth-scroll-jquery` directive and pass the target ID: `<a smooth-scroll-jquery target="target">Scroll to Target</a>`. No target means scroll to top.
 
 You can declare the speed (default is 500): `<a smooth-scroll-jquery target="target" speed="1000">Scroll to Target</a>`
 
 With both versions, you can declare the offset (default is 100): `<a smooth-scroll[-jquery] target="target" offset="30">Scroll to Target</a>`
 
-#How to contribute?
+# How to contribute?
 
 1. Clone this repo
 2. Make your changes
 3. Test them: `grunt test`
 4. Open a pull-request
 
-#To improve
+# To improve
 
 1. Vanilla JS implementation which is not working very well
 2. Make the Angular JS unit tests pass (cf. http://stackoverflow.com/questions/16929046/effectively-unit-test-an-angularjs-directive-which-is-manipulating-the-dom?noredirect=1#comment24448390_16929046)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
